### PR TITLE
Some docs improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## Contributing
+
+Find on our [roadmap](https://github.com/thompsonemerson/zoomove/issues/1) the next steps of the project ;) <br>
+Help improve these docs. Open an [issue](https://github.com/thompsonemerson/zoomove/issues/new) or submit a pull request.
+
+1. Navigate to the main page of the repository
+1. [Fork it!](https://github.com/thompsonemerson/zoomove#fork-destination-box)
+1. Create your feature branch: `git checkout -b my-new-feature`
+1. Commit your changes: `git commit -m 'Add some feature'`
+1. Push to the branch: `git push origin my-new-feature`
+1. Submit a pull request =D

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 [Emerson Thompson](http://emersonthompson.com.br/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@
   <a href="http://badge.fury.io/js/zoomove" title="npm version"><img src="https://badge.fury.io/js/zoomove.svg"/></a>
 </p>
 
+## Table of Contents
+
+- [Install](#install)
+- [Setup](#setup)
+- [How to Use](how-to-use)
+- [Examples](examples)
+- [Browser Support](#browser-support)
+- [Contributing](#contributing)
+- [History](#history)
+- [License](#license)
+
 ## Install
 
 Get with npm.
@@ -63,7 +74,7 @@ Ready, prepared environment, now is hour of our plugin take action and prepare a
 Now says it is not easy?! ;)
 
 
-## How to use
+## How to Use
 
 | Property  | Default  | Description |
 | :------------ |:---------------:| :-----|

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
-# ZooMove | jQuery Zoom Image
+<p align="center">
+  <a href="">
+    <img alt="Logo" src="demo/logo_zoomove.svg" width="600px">
+  </a>
+</p>
 
-[![licence mit](https://img.shields.io/badge/licence-MIT-blue.svg)](http://thompsonemerson.mit-license.org/)
-[![Build Status](https://travis-ci.org/thompsonemerson/zoomove.svg?branch=master)](https://travis-ci.org/thompsonemerson/zoomove)
-[![GitHub version](https://badge.fury.io/gh/thompsonemerson%2Fzoomove.svg)](https://badge.fury.io/gh/thompsonemerson%2Fzoomove)
-[![Bower version](https://badge.fury.io/bo/zoomove.svg)](https://badge.fury.io/bo/zoomove)
-[![npm version](https://badge.fury.io/js/zoomove.svg)](http://badge.fury.io/js/zoomove)
+<p align="center">
+  It's a plugin developed with *jQuery*, that allows to dynamically zoom images with mouseover, and view details with mouse move.
+</p>
 
-> It's a plugin developed with jQuery, that allows to dynamically zoom images with mouseover, and view details with mouse move.
-
+<p align="center">
+  <a href="http://thompsonemerson.mit-license.org/"><img alt="licence mit" src="https://img.shields.io/badge/licence-MIT-blue.svg"></a>
+  <a href="https://travis-ci.org/thompsonemerson/zoomove"><img alt="Build Status" src="https://travis-ci.org/thompsonemerson/zoomove.svg?branch=master"></a>
+  <a href="https://badge.fury.io/gh/thompsonemerson%2Fzoomove"><img alt="GitHub version" src="https://badge.fury.io/gh/thompsonemerson%2Fzoomove.svg"/></a>
+  <a href="https://badge.fury.io/bo/zoomove" title="Bower version"><img src="https://badge.fury.io/bo/zoomove.svg"/></a>
+  <a href="http://badge.fury.io/js/zoomove" title="npm version"><img src="https://badge.fury.io/js/zoomove.svg"/></a>
+</p>
 
 ## Install
 
@@ -44,7 +51,7 @@ First, include the script located on the `dist` folder.
 Now need to prepare our(s) image(s) and show to the ZooMove.
 ```html
 <!-- Item image -->
-<figure class="zoo-item" zoo-image="img/example.jpg"></figure> 
+<figure class="zoo-item" zoo-image="img/example.jpg"></figure>
 
 <!-- Starting the ZooMove -->
 <script>
@@ -57,24 +64,25 @@ Now says it is not easy?! ;)
 
 
 ## How to use
+
 | Property  | Default  | Description |
 | :------------ |:---------------:| :-----|
 | zoo-image     | -               | The url of the photo to be displayed.                   |
 | zoo-scale     | 1.5 (150%)      | Sets the zoom size that should be applied to the image.              |
 | zoo-move      | true            | Choose whether the image should move with the mouse move.            |
-| zoo-over      |	false           |	With 'over' it is possible to define whether the image may be above. |
-| zoo-cursor	  | false	          | Define the cursor pointer or default.                                |
+| zoo-over      |  false           |  With 'over' it is possible to define whether the image may be above. |
+| zoo-cursor    | false            | Define the cursor pointer or default.                                |
 
 ```html
 <!-- HTML Element -->
-<figure 
-	class="zoo-item" 
-	zoo-image="[value]"
-	zoo-scale="[value]"
-	zoo-move="[value]"
-	zoo-over="[value]"
-	zoo-cursor="[value]"
-	>
+<figure
+  class="zoo-item"
+  zoo-image="[value]"
+  zoo-scale="[value]"
+  zoo-move="[value]"
+  zoo-over="[value]"
+  zoo-cursor="[value]"
+  >
 </figure>
 ```
 
@@ -82,16 +90,15 @@ Now says it is not easy?! ;)
 <!-- JavaScript -->
 <script>
    $('.zoo-item').ZooMove({
-   		image: '[value]',
-     	scale: '[value]',
-     	move: '[value]',
-     	over: '[value]',
-     	cursor: '[value]'
+       image: '[value]',
+       scale: '[value]',
+       move: '[value]',
+       over: '[value]',
+       cursor: '[value]'
    });
 </script>
 <!-- Thus it is applied universally -->
 ```
-
 
 ## Browser Support
 
@@ -102,7 +109,7 @@ Now says it is not easy?! ;)
 
 ## Contributing
 
-Find on our [roadmap](https://github.com/thompsonemerson/zoomove/issues/1) the next steps of the project ;) <br> 
+Find on our [roadmap](https://github.com/thompsonemerson/zoomove/issues/1) the next steps of the project ;) <br>
 Help improve these docs. Open an [issue](https://github.com/thompsonemerson/zoomove/issues/new) or submit a pull request.
 
 - Navigate to the main page of the repository
@@ -113,6 +120,7 @@ Help improve these docs. Open an [issue](https://github.com/thompsonemerson/zoom
 - Submit a pull request =D
 
 ## History
+
 See [Releases](https://github.com/thompsonemerson/zoomove/releases) for detailed changelog.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -113,16 +113,31 @@ Now says it is not easy?! ;)
 
 ## Examples
 
+>  Images by [lorempixel](http://lorempixel.com).
+
 ![GIFs <3](https://media.giphy.com/media/3o6ozmHwJIzCaBadgI/giphy.gif)
 
+### Image 1
+
+> Default
+
 ```html
-<!-- Image 1 | Default -->
 <figure class="zoo-item" zoo-image="img/example.jpg"></figure>
+```
 
-<!-- Image 2 | Scale value "3" (300%) -->
+### Image 2
+
+> Scale value `3` (`300%`)
+
+```html
 <figure class="zoo-item" zoo-image="img/example.jpg" zoo-scale="3"></figure>
+```
 
-<!-- Image 3 | Over "true" and Move "false" -->
+### Image 3
+
+> Over `true` and Move `false`
+
+```html
 <figure class="zoo-item" zoo-image="img/example.jpg" zoo-over="true" zoo-move="false"></figure>
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ Now says it is not easy?! ;)
 Find on our [roadmap](https://github.com/thompsonemerson/zoomove/issues/1) the next steps of the project ;) <br>
 Help improve these docs. Open an [issue](https://github.com/thompsonemerson/zoomove/issues/new) or submit a pull request.
 
-- Navigate to the main page of the repository
-- [Fork it!](https://github.com/thompsonemerson/zoomove#fork-destination-box)
-- Create your feature branch: `git checkout -b my-new-feature`
-- Commit your changes: `git commit -m 'Add some feature'`
-- Push to the branch: `git push origin my-new-feature`
-- Submit a pull request =D
+1. Navigate to the main page of the repository
+1. [Fork it!](https://github.com/thompsonemerson/zoomove#fork-destination-box)
+1. Create your feature branch: `git checkout -b my-new-feature`
+1. Commit your changes: `git commit -m 'Add some feature'`
+1. Push to the branch: `git push origin my-new-feature`
+1. Submit a pull request =D
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="">
-    <img alt="Logo" src="demo/logo_zoomove.svg" width="600px">
+    <img alt="Logo" src="http://i.imgur.com/UPOSXyp.png" width="600px">
   </a>
 </p>
 
@@ -113,7 +113,7 @@ Now says it is not easy?! ;)
 
 ## Examples
 
-![GIFs <3](https://media.giphy.com/media/xT1XGOLT4erod36Z4Q/giphy.gif)
+![GIFs <3](https://media.giphy.com/media/3o6ozmHwJIzCaBadgI/giphy.gif)
 
 ```html
 <!-- Image 1 | Default -->

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 
 - [Install](#install)
 - [Setup](#setup)
-- [How to Use](how-to-use)
-- [Examples](examples)
+- [How to Use](#how-to-use)
+- [Examples](#examples)
 - [Browser Support](#browser-support)
 - [Contributing](#contributing)
 - [History](#history)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ Now says it is not easy?! ;)
 <!-- Thus it is applied universally -->
 ```
 
+## Examples
+
+![GIFs <3](https://media.giphy.com/media/xT1XGOLT4erod36Z4Q/giphy.gif)
+
+```html
+<!-- Image 1 | Default -->
+<figure class="zoo-item" zoo-image="img/example.jpg"></figure>
+
+<!-- Image 2 | Scale value "3" (300%) -->
+<figure class="zoo-item" zoo-image="img/example.jpg" zoo-scale="3"></figure>
+
+<!-- Image 3 | Over "true" and Move "false" -->
+<figure class="zoo-item" zoo-image="img/example.jpg" zoo-over="true" zoo-move="false"></figure>
+```
+
 ## Browser Support
 
 | ![Chrome](https://raw.github.com/alrra/browser-logos/master/chrome/chrome_48x48.png) | ![Firefox](https://raw.github.com/alrra/browser-logos/master/firefox/firefox_48x48.png) | ![IE](https://raw.github.com/alrra/browser-logos/master/internet-explorer/internet-explorer_48x48.png) | ![Opera](https://raw.github.com/alrra/browser-logos/master/opera/opera_48x48.png) | ![Safari](https://raw.github.com/alrra/browser-logos/master/safari/safari_48x48.png) |


### PR DESCRIPTION
Hey, nothing too special 'bout this *PR*; it just adds - or fixes - some small things in the docs:

- The project's *logo* at the top of the [`README.md`](https://github.com/mabrasil/zoomove/blob/master/README.md) to make the  project's identity clearer.
- A *gif* of a working example: instead of saying *it’s a beautiful way of enlarging images with the mouse events [...]* and leave it at that I think it's much better to **show** them with a *gif* and a code snippet - as you did in the site.
- A [Table of Contents](https://github.com/mabrasil/zoomove#table-of-contents) to make the navigation through the docs more objective.
- So many times developers don't get to read the *contributing* section in your *README* and end up sending pull requests with their own standards. I added a [`CONTRIBUTING.md`](https://github.com/mabrasil/zoomove/blob/master/CONTRIBUTING.md) file so that
whenever someone is opening a new issue or sending a pull request this appears:
  ![contributing warning](http://i.imgur.com/ndXNI3N.png)
